### PR TITLE
ci: set renovate labels

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,18 @@
     ],
     "reviewers": ["skarllot"],
     "prHourlyLimit": 0,
+    "labels": ["dependencies"],
     "packageRules": [
+        {
+            "matchDatasources": ["nuget"],
+            "addLabels": [".NET"],
+            "semanticCommitType": "build"
+        },
+        {
+            "matchDatasources": ["github-actions"],
+            "addLabels": ["github_actions"],
+            "semanticCommitType": "ci"
+        },
         {
             "matchDatasources":["dotnet-version"],
             "matchUpdateTypes":["major"],


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Azure Key Vault Reference!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- PRs created by renovate do not set labels

## Details on the issue fix or feature implementation
- Setup labels for PR
- Set semantic type for commits

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
