### PR TITLE
ci: set label for .NET version updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,12 +5,12 @@
     ],
     "reviewers": ["skarllot"],
     "prHourlyLimit": 0,
+    "semanticCommitType": "build",
     "labels": ["dependencies"],
     "packageRules": [
         {
-            "matchDatasources": ["nuget"],
-            "addLabels": [".NET"],
-            "semanticCommitType": "build"
+            "matchDatasources": ["nuget", "dotnet-version"],
+            "addLabels": [".NET"]
         },
         {
             "matchDatasources": ["github-actions"],


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Azure Key Vault Reference!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- PRs for .NET version update has no label set

## Details on the issue fix or feature implementation
- Set a `.NET` label for .NET version updates on renovate

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
