### PR TITLE
ci: use central renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,37 +1,8 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:recommended"
-    ],
-    "reviewers": ["skarllot"],
-    "prHourlyLimit": 0,
-    "semanticCommits": "enabled",
-    "semanticCommitType": "build",
-    "labels": ["dependencies"],
-    "packageRules": [
-        {
-            "matchDatasources": ["nuget", "dotnet-version"],
-            "addLabels": [".NET"],
-            "semanticCommitType": "build"
-        },
-        {
-            "matchDatasources": ["github-actions"],
-            "addLabels": ["github_actions"],
-            "semanticCommitType": "ci"
-        },
-        {
-            "matchDatasources":["dotnet-version"],
-            "matchUpdateTypes":["major"],
-            "enabled": false
-        },
-        {
-            "description": "Packages which need major versions to be in sync with the .NET version",
-            "matchDatasources": ["nuget"],
-            "matchPackagePrefixes": [
-                "Microsoft.Extensions."
-            ],
-            "matchUpdateTypes": ["major"],
-            "enabled": false
-        }
-    ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>skarllot/renovate-config"
+  ],
+  "reviewers": ["skarllot"],
+  "assignees": ["skarllot"]
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Azure Key Vault Reference!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Centralize renovate config

## Details on the issue fix or feature implementation
- Use renovate config from skarllot/renovate-config repository

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
