### PR TITLE
build: fix package icon

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>See https://github.com/skarllot/azure-keyvault-reference/releases for release notes.</PackageReleaseNotes>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Azure Key Vault Reference!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- The package icon is not set

## Details on the issue fix or feature implementation
- Add missing setting for package icon

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
