### PR TITLE
fix: trigger packaging on release publish

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
     - name: 🧰 Setup .NET
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
-        dotnet-version: 8.0.x
+        global-json-file: global.json
 
     - name: 🗃️ Setup NuGet cache
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -29,7 +29,7 @@ jobs:
     - name: 🧰 Setup .NET
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
-        dotnet-version: 8.0.x
+        global-json-file: global.json
 
     - name: 🛠️ Setup Nerdbank.GitVersioning
       run: dotnet tool install --tool-path . nbgv

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,7 +36,7 @@ jobs:
     - name: 🧰 Setup .NET
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
-        dotnet-version: 8.0.x
+        global-json-file: global.json
 
     - name: 🗃️ Setup NuGet cache
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: 🧰 Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
-          dotnet-version: 8.0.x
+          global-json-file: global.json
 
       - name: 🗃️ Setup NuGet cache
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,9 +1,9 @@
 name: Package
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [published]
+  workflow_dispatch:
 
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
@@ -32,7 +32,7 @@ jobs:
       - name: 🧰 Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
-          dotnet-version: 8.0.x
+          global-json-file: global.json
 
       - name: 🗃️ Setup NuGet cache
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Azure Key Vault Reference!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Package workflow is not being triggered

## Details on the issue fix or feature implementation
- Trigger package creation on release publish
- Use `global.json` for .NET setup

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
