### PR TITLE
fix: trigger package creation on release edit

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -2,8 +2,7 @@ name: Package
 
 on:
   release:
-    types: [published]
-  workflow_dispatch:
+    types: [published,edited]
 
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Azure Key Vault Reference!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Cannot trigger package workflow manually for older tags

## Details on the issue fix or feature implementation
- Change package workflow trigger adding release edit

## Confirm the following
- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
