### PR TITLE
ci: do not trigger package workflow on release edit

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -2,7 +2,7 @@ name: Package
 
 on:
   release:
-    types: [published,edited]
+    types: [published]
 
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Azure Key Vault Reference!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Undo work around for release last version

## Details on the issue fix or feature implementation
- Trigger package workflow only when release is published

## Confirm the following
- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
