### PR TITLE
fix: Allow setup .NET on firewall

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -30,6 +30,8 @@ jobs:
           aka.ms:443
           github.com:443
           api.nuget.org:443
+          builds.dotnet.microsoft.com:443
+          ci.dot.net:443
 
     - name: 🛒 Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,6 +30,8 @@ jobs:
             *.nuget.org:443
             aka.ms:443
             github.com:443
+            builds.dotnet.microsoft.com:443
+            ci.dot.net:443
             dc.services.visualstudio.com:443
 
       - name: 🛒 Checkout


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Azure Key Vault Reference!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Setup .NET failing because of blocked endpoints

## Details on the issue fix or feature implementation
- Update firewall rules based to allow .NET SDK endpoints

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
